### PR TITLE
Add support for PS4 controller

### DIFF
--- a/src/objects/Bullet.js
+++ b/src/objects/Bullet.js
@@ -46,7 +46,8 @@ export default class Bullet extends Phaser.Physics.Arcade.Sprite {
   }
 
   onFireGamepad(x, y, gamepad) {
-    if (gamepad.id.indexOf('Xbox Wireless Controller') > -1) {
+    if (gamepad.id.indexOf('Xbox Wireless Controller') > -1 ||
+       gamepad.id.indexOf('Wireless Controller') > -1) {
       if (gamepad.buttons[3].pressed) {
         return this.fireBullet(x, y, 'up')
       } else if (gamepad.A) {

--- a/src/objects/Bullet.js
+++ b/src/objects/Bullet.js
@@ -47,7 +47,7 @@ export default class Bullet extends Phaser.Physics.Arcade.Sprite {
 
   onFireGamepad(x, y, gamepad) {
     if (gamepad.id.indexOf('Xbox Wireless Controller') > -1 ||
-       gamepad.id.indexOf('Wireless Controller') > -1) {
+        gamepad.id.indexOf('Wireless Controller') > -1) {
       if (gamepad.buttons[3].pressed) {
         return this.fireBullet(x, y, 'up')
       } else if (gamepad.A) {


### PR DESCRIPTION
It turns out PS4 controllers have the same mapping as the Xbox controller. Not sure if this is the most elegant solution as "press A" UI elements are present which corresponds to an "X" on the PS4 controller.